### PR TITLE
feat: make RequireClientCredentialsRequirement public (WPM-7371)

### DIFF
--- a/src/Workleap.AspNetCore.Authentication.ClientCredentialsGrant/PublicAPI.Unshipped.txt
+++ b/src/Workleap.AspNetCore.Authentication.ClientCredentialsGrant/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Workleap.AspNetCore.Authentication.ClientCredentialsGrant.RequireClientCredentialsRequirement
+Workleap.AspNetCore.Authentication.ClientCredentialsGrant.RequireClientCredentialsRequirement.RequireClientCredentialsRequirement() -> void

--- a/src/Workleap.AspNetCore.Authentication.ClientCredentialsGrant/RequireClientCredentialsRequirement.cs
+++ b/src/Workleap.AspNetCore.Authentication.ClientCredentialsGrant/RequireClientCredentialsRequirement.cs
@@ -2,4 +2,11 @@
 
 namespace Workleap.AspNetCore.Authentication.ClientCredentialsGrant;
 
-internal sealed class RequireClientCredentialsRequirement : IAuthorizationRequirement;
+/// <summary>
+/// Public so that consumers can register their own <see cref="AuthorizationHandler{TRequirement}"/> for this
+/// requirement and satisfy it under custom conditions. ASP.NET Core combines handlers with OR semantics, so a
+/// consumer handler that calls <c>context.Succeed(requirement)</c> runs alongside the built-in scope check.
+/// Consumer handlers must only ever call <c>Succeed</c> (never <c>Fail</c>), as a failure would override every
+/// successful handler and block the built-in authorization path.
+/// </summary>
+public sealed class RequireClientCredentialsRequirement : IAuthorizationRequirement;


### PR DESCRIPTION
Jira issue link: [wpm-7371](https://workleap.atlassian.net/browse/wpm-7371)

## What

Changes `RequireClientCredentialsRequirement` from `internal sealed` to `public sealed`, and records the new symbols in `PublicAPI.Unshipped.txt`.

## Why

Consumers want to register their own `AuthorizationHandler<RequireClientCredentialsRequirement>` and satisfy the requirement under custom conditions (e.g. an alternate auth path), without losing the built-in scope check.

This is the idiomatic ASP.NET Core extensibility model: a requirement can have multiple handlers, combined with **OR semantics** — the requirement is satisfied if *any* handler calls `context.Succeed(requirement)`. The built-in `RequireClientCredentialsRequirementHandler` only ever succeeds (never calls `Fail`) and is registered via `TryAddEnumerable`, so a consumer handler runs alongside it rather than replacing it.

A doc comment on the type documents the extension point and the key caveat: consumer handlers must only ever call `Succeed`, never `Fail` (a failure overrides every successful handler).

## Testing

- Built the library + unit-test project (Release).
- Authorization unit tests (`RequireClientCredentialsRequirementHandlerTests`, `AuthorizationExtensionsTest`) pass: 9/9.

> Note: the `OpenApiSecurityDescriptionTests` integration test was not run locally — it shells out to `dotnet build` against the `WebApi.OpenAPI.SystemTest` project, which requires the private NuGet feed (unavailable in this environment). It is unrelated to this change and will run in CI.

WPM-7371

🤖 Generated with [Claude Code](https://claude.com/claude-code)
